### PR TITLE
Laravel 6 fixes

### DIFF
--- a/src/AlternativeLaravelCache/Provider/AlternativeCacheStoresServiceProvider.php
+++ b/src/AlternativeLaravelCache/Provider/AlternativeCacheStoresServiceProvider.php
@@ -7,6 +7,7 @@ use AlternativeLaravelCache\Store\AlternativeHierarchialFileCacheStore;
 use AlternativeLaravelCache\Store\AlternativeRedisCacheStore;
 use Doctrine\Instantiator\Exception\InvalidArgumentException;
 use Illuminate\Cache\CacheManager;
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
@@ -67,7 +68,7 @@ class AlternativeCacheStoresServiceProvider extends ServiceProvider {
         switch (strtolower($cacheConfig['driver'])) {
             case static::$fileDriverName:
             case static::$hierarchialFileDriverName:
-                return new Local($cacheConfig['path'], LOCK_EX, Local::DISALLOW_LINKS, array_get($cacheConfig, 'permissions') ?: []);
+                return new Local($cacheConfig['path'], LOCK_EX, Local::DISALLOW_LINKS, Arr::get($cacheConfig, 'permissions') ?: []);
             default:
                 throw new InvalidArgumentException("File cache driver [{$cacheConfig['driver']}] is not supported.
                     You can add support for drivers by overwriting " . __CLASS__ . '->makeFileCacheAdapter() method');
@@ -80,7 +81,7 @@ class AlternativeCacheStoresServiceProvider extends ServiceProvider {
      * @return string
      */
     static public function getPrefix(array $config) {
-        return array_get($config, 'prefix') ?: config('cache.prefix');
+        return Arr::get($config, 'prefix') ?: config('cache.prefix');
     }
 
     /**
@@ -88,6 +89,6 @@ class AlternativeCacheStoresServiceProvider extends ServiceProvider {
      * @return string
      */
     static public function getConnectionName(array $cacheConfig) {
-        return array_get($cacheConfig, 'connection', 'default') ?: 'default';
+        return Arr::get($cacheConfig, 'connection', 'default') ?: 'default';
     }
 }


### PR DESCRIPTION
Hello,

First of all, thank you for merging my last PR.

Using the newest package version gives an error when trying to load it on Laravel 6. The reason is that Laravel has dropped modified the way to use helper functions. 

https://laravel.com/docs/6.0/helpers#method-array-get 

This PR solves the issue and keeps compatibility across all versions, since the `Arr` support class exists on all versions.

https://laravel.com/api/5.2/Illuminate/Support/Arr.html#method_get 
