### PR TITLE
Update app version to be compatible with Lumen.

### DIFF
--- a/src/AlternativeLaravelCache/Core/AlternativeCacheStore.php
+++ b/src/AlternativeLaravelCache/Core/AlternativeCacheStore.php
@@ -307,7 +307,7 @@ abstract class AlternativeCacheStore extends TaggableStore implements Store {
      */
     protected function isDurationInSeconds() {
         if ($this->isDurationInSeconds === null) {
-            $this->isDurationInSeconds = preg_match('%^.*?(\d+\.\d+)%', \App::version(), $matches) && (float)$matches[1] >= 5.8;
+            $this->isDurationInSeconds = preg_match('%^.*?(\d+\.\d+)%', app()->version(), $matches) && (float)$matches[1] >= 5.8;
         }
         return $this->isDurationInSeconds;
     }


### PR DESCRIPTION
This PR fixes an issue with grabbing the app version when this package is installed inside of a Lumen based application. 

Lumen does not have a `\App` based namespace. This has been updated to use `app()` instead.

This PR should also fix issue #4 