### PR TITLE
Return parent return values to avoid breaking cron

### DIFF
--- a/src/AlternativeLaravelCache/Core/AlternativeCacheStore.php
+++ b/src/AlternativeLaravelCache/Core/AlternativeCacheStore.php
@@ -155,7 +155,7 @@ abstract class AlternativeCacheStore extends TaggableStore implements Store {
      * @throws \Psr\Cache\InvalidArgumentException
      */
     public function put($key, $value, $duration) {
-        $this->getWrappedConnection()->save($this->newItem($key, $value, $this->_pullTags(), $duration));
+        return $this->getWrappedConnection()->save($this->newItem($key, $value, $this->_pullTags(), $duration));
     }
 
     /**
@@ -173,7 +173,7 @@ abstract class AlternativeCacheStore extends TaggableStore implements Store {
         foreach ($values as $key => $value) {
             $this->getWrappedConnection()->saveDeferred($this->newItem($key, $value, $tags));
         }
-        $this->getWrappedConnection()->commit();
+        return $this->getWrappedConnection()->commit();
     }
 
     /**
@@ -225,7 +225,7 @@ abstract class AlternativeCacheStore extends TaggableStore implements Store {
      * @throws \Psr\Cache\InvalidArgumentException
      */
     public function forever($key, $value) {
-        $this->getWrappedConnection()->save($this->newItem($key, $value, $this->_pullTags()));
+        return $this->getWrappedConnection()->save($this->newItem($key, $value, $this->_pullTags()));
     }
 
     /**

--- a/src/AlternativeLaravelCache/Core/AlternativeTaggedCache.php
+++ b/src/AlternativeLaravelCache/Core/AlternativeTaggedCache.php
@@ -43,7 +43,7 @@ class AlternativeTaggedCache extends TaggedCache {
      */
     public function put($key, $value, $ttl = null) {
         $this->sendTagsToStore();
-        parent::put($key, $value, $ttl);
+        return parent::put($key, $value, $ttl);
     }
 
     /**
@@ -55,7 +55,7 @@ class AlternativeTaggedCache extends TaggedCache {
      */
     public function putMany(array $values, $ttl = null) {
         $this->sendTagsToStore();
-        parent::putMany($values, $ttl);
+        return parent::putMany($values, $ttl);
     }
 
     /**
@@ -67,7 +67,7 @@ class AlternativeTaggedCache extends TaggedCache {
      */
     public function forever($key, $value) {
         $this->sendTagsToStore();
-        parent::forever($key, $value);
+        return parent::forever($key, $value);
     }
 
     /**


### PR DESCRIPTION
Fix cron scheduler issuing **Skipping command (has already run on another server)** when using **->onOneServer()** (as in https://github.com/swayok/alternative-laravel-cache/issues/16)