### PR TITLE
Updated RedisCacheStore implementation to allow for RedisCluster when using phpredis extension

### DIFF
--- a/AlternativeLaravelCache/Store/AlternativeRedisCacheStore.php
+++ b/AlternativeLaravelCache/Store/AlternativeRedisCacheStore.php
@@ -27,7 +27,9 @@ class AlternativeRedisCacheStore extends AlternativeCacheStore {
      */
     public function wrapConnection() {
         $connection = $this->getConnection();
-        if (get_class($connection) === 'Redis') {
+        $connectionClass = get_class($connection);
+
+        if ($connectionClass === 'Redis' || $connectionClass === 'RedisCluster') {
             // PHPRedis extension client
             return new RedisCachePool($connection);
         } else {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,10 +6,6 @@
     colors="true"
 >
     <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>


### PR DESCRIPTION
As per the title, this updates the RedisCacheStore implementation, adding support for redis clusters.

The current check to identify the extension/library being used only accounted for an instance of Redis to be returned, however, when using redis in cluster formation, a class instance of RedisCluster is returned.

this simple update, allows for that.

As an addition, when running the tests, I received failures due to a non-existent suite, Unit, so I removed the declaration to prevent the errors.