### PR TITLE
refactor: determine hierarchy separator without creating connections

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+vendor
+.git

--- a/AlternativeLaravelCache/Core/AlternativeCacheStore.php
+++ b/AlternativeLaravelCache/Core/AlternativeCacheStore.php
@@ -18,11 +18,6 @@ abstract class AlternativeCacheStore extends TaggableStore {
     protected $db;
 
     /**
-     * @var string
-     */
-    public $hierarchySeparator;
-
-    /**
      * A string that should be prepended to keys.
      *
      * @var string
@@ -107,15 +102,14 @@ abstract class AlternativeCacheStore extends TaggableStore {
         return $this->wrappedConnection;
     }
 
+    /**
+     * Retrieve the hierarchy separator.
+     * Defaults to '_'.
+     * 
+     * @return string 
+     */
     public function getHierarchySeparator() {
-        if ($this->hierarchySeparator) {
-            return $this->hierarchySeparator;
-        }
-        $this->hierarchySeparator = '_';
-        if ($this->getWrappedConnection() instanceof HierarchicalPoolInterface) {
-            $this->hierarchySeparator = HierarchicalPoolInterface::HIERARCHY_SEPARATOR;
-        }
-        return $this->hierarchySeparator;
+        return '_';
     }
 
     /**

--- a/AlternativeLaravelCache/Store/AlternativeHierarchialFileCacheStore.php
+++ b/AlternativeLaravelCache/Store/AlternativeHierarchialFileCacheStore.php
@@ -32,6 +32,10 @@ class AlternativeHierarchialFileCacheStore extends AlternativeCacheStore {
         }
     }
 
+    public function getHierarchySeparator() {
+       return HierarchicalPoolInterface::HIERARCHY_SEPARATOR;
+    }
+
     public function setPrefix($prefix) {
         // allowed chars: "a-zA-Z0-9_.! "
         parent::setPrefix(preg_replace('%[^a-zA-Z0-9_\.! ]+%', '_', $prefix));

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:8.1-fpm
+
+WORKDIR /workspace
+
+VOLUME ["/workspace"]
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+RUN apt update -y \
+    && apt install -y unzip git --no-install-recommends \
+    && rm -rf /var/lib/apt/lists
+
+RUN pecl install redis-5.3.7 \
+    && docker-php-ext-enable redis
+
+COPY composer.* ./
+
+RUN composer install
+
+COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  alternative-laravel-cache-test:
+    container_name: alternative-laravel-cache
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: vendor/bin/phpunit
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+  redis:
+    container_name: alternative-laravel-cache-redis
+    image: redis:7.0
+
+networks:
+  default:
+    name: alternative-laravel-cache-network


### PR DESCRIPTION
After diving a bit deeper into the code, it seems the only problem is the hierarchy separator being different for the AlternativeLaravelCache/Store/AlternativeHierarchialFileCacheStore.php, as it is the only one which uses cache pools that inherit from HierarchicalCachePool (HierarchialFilesystemCachePoolFlysystem1 and HierarchialFilesystemCachePoolFlysystem3).

Therefore the most simple solution is to override the return value for that store and remove the original check.

I've also added a simple docker setup for running the existing tests easily.