### PR TITLE
Fixed alternative cache not registering when using Predis.

### DIFF
--- a/AlternativeLaravelCache/Provider/AlternativeCacheStoresServiceProvider.php
+++ b/AlternativeLaravelCache/Provider/AlternativeCacheStoresServiceProvider.php
@@ -48,7 +48,7 @@ class AlternativeCacheStoresServiceProvider extends ServiceProvider
     {
         $cacheManager = $this->app->make('cache');
         $hasLocks = trait_exists('\Illuminate\Cache\HasCacheLock');
-        if ($this->isRedisDriverEnabled()) {
+        if ($this->isRedisDriverEnabled() || $this->isPredisDriverEnabled()) {
             $this->addRedisCacheDriver($cacheManager, $hasLocks);
         }
         if ($this->isMemcachedDriverEnabled()) {
@@ -215,6 +215,12 @@ class AlternativeCacheStoresServiceProvider extends ServiceProvider
     {
         /** @noinspection ClassConstantCanBeUsedInspection */
         return class_exists('\Cache\Adapter\Redis\RedisCachePool');
+    }
+
+    protected function isPredisDriverEnabled(): bool
+    {
+        /** @noinspection ClassConstantCanBeUsedInspection */
+        return class_exists('\Cache\Adapter\Predis\PredisCachePool');
     }
 
     protected function isMemcachedDriverEnabled(): bool


### PR DESCRIPTION
When upgrading to 6.1.10 I noticed that the alternative cache driver wasn't being used anymore.

A bit of a search later I discovered the reason was that you enable the alternative Redis cache when `'\Cache\Adapter\Redis\RedisCachePool'` exists. However, I'm currently using Predis, so it didn't add the alternative Redis cache driver.

This PR adds a check for Predis to enable the alternative Redis cache.