### PR TITLE
Fix bug that occurs when trying to set an empty prefix with 'prefix'=>''

### DIFF
--- a/AlternativeLaravelCache/Provider/AlternativeCacheStoresServiceProvider.php
+++ b/AlternativeLaravelCache/Provider/AlternativeCacheStoresServiceProvider.php
@@ -247,7 +247,7 @@ class AlternativeCacheStoresServiceProvider extends ServiceProvider
      */
     public function getPrefix(array $config): string
     {
-        return Arr::get($config, 'prefix') ?: config('cache.prefix');
+        return Arr::get($config, 'prefix') ?? config('cache.prefix');
     }
 
     public function getConnectionName(array $cacheConfig): string


### PR DESCRIPTION
I tried to set an empty prefix for the altfile driver, but it didn't work.

Below is the relevant configuration from config/cache.php:

```        
'altfile' => [
            'driver' => 'altfile',
            'path' => storage_path('framework/cache/data'),
            'lock_path' => storage_path('framework/cache/data'),
            'prefix' => '',
        ],
```

However, despite this configuration, the default prefix from Laravel was still applied:

```
      'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache_'),
```