### PR TITLE
Check for null before accessing array keys

### DIFF
--- a/AlternativeLaravelCache/Vendors/Array/ArrayCachePool.php
+++ b/AlternativeLaravelCache/Vendors/Array/ArrayCachePool.php
@@ -242,7 +242,7 @@ class ArrayCachePool extends AbstractCachePool implements HierarchicalPoolInterf
         $array = $this->cache;
 
         foreach ($keys as $key) {
-            if ($has = array_key_exists($key, $array)) {
+            if (!is_null($array) && $has = array_key_exists($key, $array)) {
                 $array = $array[$key];
             }
         }


### PR DESCRIPTION
Fixing issue raised with new version. Laravel php unit testing is throwing the following error on every test

```
  array_key_exists(): Argument #2 ($array) must be of type array, null given

  at vendor/swayok/alternative-laravel-cache/AlternativeLaravelCache/Vendors/Array/ArrayCachePool.php:245
    241▕         $has = false;
    242▕         $array = $this->cache;
    243▕ 
    244▕         foreach ($keys as $key) {
  ➜ 245▕             if ($has = array_key_exists($key, $array)) {
    246▕                 $array = $array[$key];
    247▕             }
    248▕         }
    249▕ 
```